### PR TITLE
fix issue with previously-selected cart options

### DIFF
--- a/cart_implementations/backbone/scripts/master.js
+++ b/cart_implementations/backbone/scripts/master.js
@@ -1280,6 +1280,8 @@ app.views.Item = Backbone.View.extend({
               value.selected = true;
             } else if (value.value == selectedValue) {
               value.selected = true;
+            } else {
+              value.selected = false;
             }
           });
         }


### PR DESCRIPTION
The `<select>` dropdowns in the cart were not always being updated correctly, though the price was correct. Multiple `<options>` had the `selected` attribute set. This commit sets the `selected` attribute to false if the current option is not the default or selected option.