### PR TITLE
fix estimateShipping call

### DIFF
--- a/cart_implementations/backbone/scripts/handlebars/shipping_template.handlebars
+++ b/cart_implementations/backbone/scripts/handlebars/shipping_template.handlebars
@@ -6,7 +6,7 @@ No available shipping methods found.
 {{#if showDropdown}}
 <select class='selectShippingPreference' name="shipping[preference]">
   {{#each methods}}
-  {{#ucSelectOption2 name ../selectedMethod}}{{cost}} {{name}}{{/ucSelectOption2}}
+  {{#ucSelectOption2 name ../selectedMethod}}{{cost}} {{displayName}}{{/ucSelectOption2}}
   {{/each}}
 </select>
 {{else}}

--- a/cart_implementations/backbone/scripts/master.js
+++ b/cart_implementations/backbone/scripts/master.js
@@ -495,13 +495,21 @@ app.commonFunctions.estimateShipping = function () {
     app.data.bootstrap.set({'fetchingShipping': true});
 
     jQuery.ajax({
-      url: restUrl + '/estimateShipping', // restUrl is defined in the html page.
-      type: 'POST',
-      async: true,
-      'contentType': 'application/json; charset=UTF-8',
-      data: JSON.stringify(app.data.cart.toJSON()),
-      dataType: 'json'
-    }).done(
+        url: restUrl,
+        type: 'PUT', // Notice
+        headers : { "cache-control": "no-cache" },
+        contentType: 'application/json; charset=UTF-8',
+        data: JSON.stringify(app.data.cart.toJSON()),
+        dataType: 'json'
+    }).done(function (updatedCart) {
+        jQuery.ajax({
+          url: restUrl + '/estimateShipping', // restUrl is defined in the html page.
+          type: 'POST',
+          async: true,
+          'contentType': 'application/json; charset=UTF-8',
+          data: JSON.stringify(app.data.cart.toJSON()),
+          dataType: 'json'
+        }).done(
             function (shippingEstimates) {
               if (shippingEstimates) {
                 if (shippingEstimates.length) {
@@ -550,7 +558,7 @@ app.commonFunctions.estimateShipping = function () {
             }).always(function () {
               app.data.bootstrap.set({'fetchingShipping': false});
             });
-
+      });
   }
 };
 

--- a/cart_implementations/backbone/scripts/master.js
+++ b/cart_implementations/backbone/scripts/master.js
@@ -1069,6 +1069,7 @@ app.views.ShippingAddress = Backbone.View.extend({
   'useStoredAddress': function (event) {
     var oid = event.target.value;
     app.commonFunctions.useShippingAddress(parseInt(oid));
+    app.commonFunctions.estimateShipping();
   }
 
 

--- a/cart_implementations/backbone/scripts/master_template.js
+++ b/cart_implementations/backbone/scripts/master_template.js
@@ -655,8 +655,8 @@ function program6(depth0,data) {
   else { helper = (depth0 && depth0.cost); stack1 = typeof helper === functionType ? helper.call(depth0, {hash:{},data:data}) : helper; }
   buffer += escapeExpression(stack1)
     + " ";
-  if (helper = helpers.name) { stack1 = helper.call(depth0, {hash:{},data:data}); }
-  else { helper = (depth0 && depth0.name); stack1 = typeof helper === functionType ? helper.call(depth0, {hash:{},data:data}) : helper; }
+  if (helper = helpers.displayName) { stack1 = helper.call(depth0, {hash:{},data:data}); }
+  else { helper = (depth0 && depth0.displayName); stack1 = typeof helper === functionType ? helper.call(depth0, {hash:{},data:data}) : helper; }
   buffer += escapeExpression(stack1);
   return buffer;
   }


### PR DESCRIPTION
The shipping method displayName is user-editable in the UltraCart interface, though the method name does not appear to be. Radio buttons already use displayName but somehow the select was overlooked, and this commit fixes that.